### PR TITLE
fix: increase paddle visibility w CSS

### DIFF
--- a/handtrack/index.html
+++ b/handtrack/index.html
@@ -30,16 +30,16 @@
 		width: 20px;
 		height: 100px;
 		position: absolute;
+		background-color: aqua;
+		border: 1px solid black;
 	}
 
 	#player1 {
 		left: 50px;
-		border-right: 2px #101010 solid;
 	}
 
 	#player2 {
 		right: 50px;
-		border-left: 2px #101010 solid;
 	}
 
 	main {
@@ -88,6 +88,7 @@
 	#scorejoueur2 {
 		right: 25%;
 	}
+
 	#loader {
 		position: absolute;
 		top: 10%;
@@ -95,14 +96,14 @@
 	}
 </style>
 <link rel="icon" type="image/x-icon" href="favicon.ico">
+
 <head>
 	<title>HandGame</title>
 </head>
 
 <body>
-	<h2 id="loader">loading model...</h2> 
-	<video style="width: 100%; height: 100%;" id="videoelement" controls
-		poster="loading.png">
+	<h2 id="loader">loading model...</h2>
+	<video style="width: 100%; height: 100%;" id="videoelement" controls poster="loading.png">
 	</video>
 	<canvas id="result" style="width: 560px; height: 420px;"> </canvas>
 
@@ -111,7 +112,7 @@
 		<div id="player2" class="player"></div>
 		<div id="middleline"></div>
 		<div id="ball"></div>
-		<ul class="score" >
+		<ul class="score">
 			<li id="scoreplayer1">0</li>
 			<li id="scoreplayer2">0</li>
 		</ul>


### PR DESCRIPTION
Increased visibility and contrast of paddles. Previously they were too thin and were hard to see from the back of the meetup seating.

| Before | After |
|--|--|
| <img width="1434" alt="image" src="https://user-images.githubusercontent.com/24983797/188872741-1951cd2e-3596-431c-a1c3-996aea984436.png"> | <img width="1434" alt="image" src="https://user-images.githubusercontent.com/24983797/188872932-b364b8ef-e3e0-4189-8527-29a97e024c02.png"> |